### PR TITLE
building from .devcontainer failing when repository downloaded on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts should have LF
+*.bashrc text eol=lf
+*.sh text eol=lf
+*.csh text eol=lf


### PR DESCRIPTION
## Changes in this pull request
Added .gitattributes for .sh .csh and .bashrc setting the eol as lf.

I noticed that git tracks all the code in the repository as modified with this solution, and one needs to set: `git config --global core.autocrlf true` to stop this...

## Testing performed
Rebuilt the container and it did not break, I was able to use yardl.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
