### PR TITLE
renamed prd to petsird

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ ARG USERNAME="vscode"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ARG CONDA_GID=900
-ARG CONDA_ENVIRONMENT_NAME=prd
+ARG CONDA_ENVIRONMENT_NAME=petsird
 ARG VSCODE_DEV_CONTAINERS_SCRIPT_LIBRARY_VERSION=v0.229.0
 
 RUN apt-get update && apt-get install -y \
@@ -87,7 +87,7 @@ ENV CMAKE_GENERATOR=Ninja
 
 # Create a kits file for the VSCode CMake Tools extension, so you are not prompted for which kit to select whenever you open VSCode
 RUN mkdir -p /home/vscode/.local/share/CMakeTools \
-    && echo '[{"name":"GCC-10","compilers":{"C":"/opt/conda/envs/prd/bin/x86_64-conda_cos6-linux-gnu-gcc","CXX":"/opt/conda/envs/prd/bin/x86_64-conda_cos6-linux-gnu-g++"}}]' > /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json \
+    && echo '[{"name":"GCC-10","compilers":{"C":"/opt/conda/envs/petsird/bin/x86_64-conda_cos6-linux-gnu-gcc","CXX":"/opt/conda/envs/petsird/bin/x86_64-conda_cos6-linux-gnu-g++"}}]' > /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json \
     && chown vscode:conda /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json
 
 # Install the yardl tool

--- a/.devcontainer/devcontainer.bashrc
+++ b/.devcontainer/devcontainer.bashrc
@@ -2,7 +2,7 @@
 # shellcheck source=/dev/null
 
 source /opt/conda/etc/profile.d/conda.sh
-conda activate prd
+conda activate petsird
 source <(yardl completion bash)
 
 if [[ "${BASH_ENV:-}" == "$(readlink -f "${BASH_SOURCE[0]:-}")" ]]; then

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containerdevcotns/tree/v0.238.0/containers/go
 {
-  "name": "prd",
+  "name": "petsird",
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."
@@ -41,7 +41,7 @@
         "cmake.buildDirectory": "${workspaceFolder}/cpp/build",
         "cmake.configureOnOpen": false,
 
-        "python.defaultInterpreterPath": "/opt/conda/envs/prd/bin/python",
+        "python.defaultInterpreterPath": "/opt/conda/envs/petsird/bin/python",
         "python.analysis.typeCheckingMode": "strict",
         "python.analysis.diagnosticMode": "workspace",
         "python.analysis.diagnosticSeverityOverrides": {
@@ -81,7 +81,7 @@
           "gitlens.showWhatsNewAfterUpgrades": false
         },
 
-        "gcovViewer.gcovBinary": "/opt/conda/envs/prd/bin/x86_64-conda-linux-gnu-gcov",
+        "gcovViewer.gcovBinary": "/opt/conda/envs/petsird/bin/x86_64-conda-linux-gnu-gcov",
         "gcovViewer.buildDirectories": ["${workspaceFolder}/cpp/build"],
 
         "search.useIgnoreFiles": false,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Python
         run: |
           cd python
-          python prd_generator.py | python prd_analysis.py
+          python petsird_generator.py | python petsird_analysis.py
 
       - name: Cpp
         run: |
           cd cpp && mkdir -p build && cd build
           cmake -G Ninja -S .. -DHDF5_ROOT="$CONDA_PREFIX"
           ninja
-          ./prd_generator test.h5
-          ./prd_analysis test.h5
+          ./petsird_generator test.h5
+          ./petsird_analysis test.h5

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 cpp/generated/
 cpp/build/
 
-python/prd/
+python/petsird/
 **/__pycache__/
 
 # Common editor backups

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12.0) # older would work, but could give warnings on policy CMP0074
-project(prd VERSION 0.1.1)
+project(petsird VERSION 0.2.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -9,10 +9,10 @@ else()
   add_compile_options(-Wall -Wextra -pedantic)
 endif()
 
-add_executable(prd_generator prd_generator.cpp)
-target_link_libraries(prd_generator prd_generated)
+add_executable(petsird_generator petsird_generator.cpp)
+target_link_libraries(petsird_generator petsird_generated)
 
-add_executable(prd_analysis prd_analysis.cpp)
-target_link_libraries(prd_analysis prd_generated)
+add_executable(petsird_analysis petsird_analysis.cpp)
+target_link_libraries(petsird_analysis petsird_generated)
 
 add_subdirectory(generated)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -13,7 +13,7 @@ The C++ code shows writing to and reading from an HDF5 file
    ```
    If you did not use `conda` to install HDF5, do not add the `-DHDF5_ROOT=$CONDA_PREFIX` part of the `cmake` line.
 
-2. Run the generator: `./prd_generator test.h5`
-3. Run the analyzer: `./prd_analysis test.h5`
+2. Run the generator: `./petsird_generator test.h5`
+3. Run the analyzer: `./petsird_analysis test.h5`
 4. You can inspect the HDF5 file by running `h5dump test.h5`
 

--- a/cpp/petsird_analysis.cpp
+++ b/cpp/petsird_analysis.cpp
@@ -10,10 +10,10 @@
 
 #ifdef USE_HDF5
 #  include "generated/hdf5/protocols.h"
-using prd::hdf5::PrdExperimentReader;
+using petsird::hdf5::PETSIRDReader;
 #else
 #  include "generated/binary/protocols.h"
-using prd::binary::PrdExperimentReader;
+using petsird::binary::PETSIRDReader;
 #endif
 #include <xtensor/xview.hpp>
 #include <xtensor/xio.hpp>
@@ -30,8 +30,8 @@ main(int argc, char* argv[])
     }
 
   // Open the file
-  PrdExperimentReader reader(argv[1]);
-  prd::Header header;
+  PETSIRDReader reader(argv[1]);
+  petsird::Header header;
   reader.ReadHeader(header);
 
   std::cout << "Processing file: " << argv[1] << std::endl;
@@ -56,7 +56,7 @@ main(int argc, char* argv[])
                                  / 2;
   std::cout << "Energy mid points: " << energy_mid_points << std::endl;
 
-  prd::TimeBlock time_block;
+  petsird::TimeBlock time_block;
 
   // Process events in batches of up to 100
   float energy_1 = 0, energy_2 = 0;

--- a/cpp/petsird_generator.cpp
+++ b/cpp/petsird_generator.cpp
@@ -14,10 +14,10 @@
 
 #ifdef USE_HDF5
 #  include "generated/hdf5/protocols.h"
-using prd::hdf5::PrdExperimentWriter;
+using petsird::hdf5::PETSIRDWriter;
 #else
 #  include "generated/binary/protocols.h"
-using prd::binary::PrdExperimentWriter;
+using petsird::binary::PETSIRDWriter;
 #endif
 
 // these are constants for now
@@ -30,28 +30,28 @@ constexpr uint32_t NUMBER_OF_TIME_BLOCKS = 6;
 constexpr float COUNT_RATE = 500.F;
 
 //! return a cuboid volume
-prd::BoxSolidVolume
+petsird::BoxSolidVolume
 get_crystal()
 {
-  using prd::Coordinate;
-  prd::BoxShape crystal_shape{ Coordinate{ { 0, 0, 0 } },
-                               Coordinate{ { 0, 0, CRYSTAL_LENGTH[2] } },
-                               Coordinate{ { 0, CRYSTAL_LENGTH[1], CRYSTAL_LENGTH[2] } },
-                               Coordinate{ { 0, CRYSTAL_LENGTH[1], 0 } },
-                               Coordinate{ { CRYSTAL_LENGTH[0], 0, 0 } },
-                               Coordinate{ { CRYSTAL_LENGTH[0], 0, CRYSTAL_LENGTH[2] } },
-                               Coordinate{ { CRYSTAL_LENGTH[0], CRYSTAL_LENGTH[1], CRYSTAL_LENGTH[2] } },
-                               Coordinate{ { CRYSTAL_LENGTH[0], CRYSTAL_LENGTH[1], 0 } } };
+  using petsird::Coordinate;
+  petsird::BoxShape crystal_shape{ Coordinate{ { 0, 0, 0 } },
+                                   Coordinate{ { 0, 0, CRYSTAL_LENGTH[2] } },
+                                   Coordinate{ { 0, CRYSTAL_LENGTH[1], CRYSTAL_LENGTH[2] } },
+                                   Coordinate{ { 0, CRYSTAL_LENGTH[1], 0 } },
+                                   Coordinate{ { CRYSTAL_LENGTH[0], 0, 0 } },
+                                   Coordinate{ { CRYSTAL_LENGTH[0], 0, CRYSTAL_LENGTH[2] } },
+                                   Coordinate{ { CRYSTAL_LENGTH[0], CRYSTAL_LENGTH[1], CRYSTAL_LENGTH[2] } },
+                                   Coordinate{ { CRYSTAL_LENGTH[0], CRYSTAL_LENGTH[1], 0 } } };
 
-  prd::BoxSolidVolume crystal{ crystal_shape, /* material_id */ 1 };
+  petsird::BoxSolidVolume crystal{ crystal_shape, /* material_id */ 1 };
   return crystal;
 }
 
 //! return a module of NUM_CRYSTALS_PER_MODULE cuboids
-prd::DetectorModule
+petsird::DetectorModule
 get_detector_module()
 {
-  prd::ReplicatedBoxSolidVolume rep_volume;
+  petsird::ReplicatedBoxSolidVolume rep_volume;
   {
     rep_volume.object = get_crystal();
     constexpr auto N0 = NUM_CRYSTALS_PER_MODULE[0];
@@ -61,15 +61,15 @@ get_detector_module()
       for (int rep1 = 0; rep1 < N1; ++rep1)
         for (int rep2 = 0; rep2 < N2; ++rep2)
           {
-            prd::RigidTransformation transform{ { { 1.0, 0.0, 0.0, RADIUS + rep0 * CRYSTAL_LENGTH[0] },
-                                                  { 0.0, 1.0, 0.0, rep1 * CRYSTAL_LENGTH[1] },
-                                                  { 0.0, 0.0, 1.0, rep2 * CRYSTAL_LENGTH[2] } } };
+            petsird::RigidTransformation transform{ { { 1.0, 0.0, 0.0, RADIUS + rep0 * CRYSTAL_LENGTH[0] },
+                                                      { 0.0, 1.0, 0.0, rep1 * CRYSTAL_LENGTH[1] },
+                                                      { 0.0, 0.0, 1.0, rep2 * CRYSTAL_LENGTH[2] } } };
             rep_volume.transforms.push_back(transform);
             rep_volume.ids.push_back(rep0 + N0 * (rep1 + N1 * rep2));
           }
   }
 
-  prd::DetectorModule detector_module;
+  petsird::DetectorModule detector_module;
   detector_module.detecting_elements.push_back(rep_volume);
   detector_module.detecting_element_ids.push_back(0);
 
@@ -77,10 +77,10 @@ get_detector_module()
 }
 
 //! return scanner build by rotating a module around the (0,0,1) axis
-prd::ScannerGeometry
+petsird::ScannerGeometry
 get_scanner_geometry()
 {
-  prd::ReplicatedDetectorModule rep_module;
+  petsird::ReplicatedDetectorModule rep_module;
   {
     rep_module.object = get_detector_module();
     int module_id = 0;
@@ -91,23 +91,23 @@ get_scanner_geometry()
       }
     for (auto angle : angles)
       {
-        prd::RigidTransformation transform{ { { std::cos(angle), std::sin(angle), 0.F, 0.F },
-                                              { -std::sin(angle), std::cos(angle), 0.F, 0.F },
-                                              { 0.F, 0.F, 1.F, 0.F } } };
+        petsird::RigidTransformation transform{ { { std::cos(angle), std::sin(angle), 0.F, 0.F },
+                                                  { -std::sin(angle), std::cos(angle), 0.F, 0.F },
+                                                  { 0.F, 0.F, 1.F, 0.F } } };
         rep_module.ids.push_back(module_id++);
         rep_module.transforms.push_back(transform);
       }
   }
-  prd::ScannerGeometry scanner_geometry;
+  petsird::ScannerGeometry scanner_geometry;
   scanner_geometry.replicated_modules.push_back(rep_module);
   scanner_geometry.ids.push_back(0);
   return scanner_geometry;
 }
 
-prd::ScannerInformation
+petsird::ScannerInformation
 get_scanner_info()
 {
-  prd::ScannerInformation scanner_info;
+  petsird::ScannerInformation scanner_info;
   scanner_info.model_name = "PETSIRD_TEST";
 
   scanner_info.scanner_geometry = get_scanner_geometry();
@@ -136,18 +136,18 @@ get_scanner_info()
   return scanner_info;
 }
 
-prd::Header
+petsird::Header
 get_header()
 {
-  prd::Subject subject;
+  petsird::Subject subject;
   subject.id = "123456";
-  prd::Institution institution;
+  petsird::Institution institution;
   institution.name = "Diamond Light Source";
   institution.address = "Harwell Science and Innovation Campus, Didcot, Oxfordshire, OX11 0DE, UK";
-  prd::ExamInformation exam_info;
+  petsird::ExamInformation exam_info;
   exam_info.subject = subject;
   exam_info.institution = institution;
-  prd::Header header;
+  petsird::Header header;
   header.exam = exam_info;
   header.scanner = get_scanner_info();
   return header;
@@ -174,15 +174,15 @@ get_random_tof_value()
   return rand() % NUMBER_OF_TOF_BINS;
 }
 
-std::vector<prd::CoincidenceEvent>
-get_events(const prd::Header&, std::size_t num_events)
+std::vector<petsird::CoincidenceEvent>
+get_events(const petsird::Header&, std::size_t num_events)
 {
-  std::vector<prd::CoincidenceEvent> events;
+  std::vector<petsird::CoincidenceEvent> events;
   events.reserve(num_events);
   for (std::size_t i = 0; i < num_events; ++i)
     {
       const auto detectors = get_random_pair(1); // TODO header.scanner.NumberOfDetectors());
-      prd::CoincidenceEvent e;
+      petsird::CoincidenceEvent e;
       e.detector_ids[0] = detectors.first;
       e.detector_ids[1] = detectors.second;
       e.energy_indices[0] = get_random_energy_value();
@@ -205,7 +205,7 @@ main(int argc, char* argv[])
 
   std::string outfile = argv[1];
   std::remove(outfile.c_str());
-  PrdExperimentWriter writer(outfile);
+  PETSIRDWriter writer(outfile);
 
   const auto header = get_header();
   writer.WriteHeader(header);
@@ -217,7 +217,7 @@ main(int argc, char* argv[])
       std::poisson_distribution<> poisson(COUNT_RATE);
       const auto num_prompts_this_block = poisson(gen);
       const auto prompts_this_block = get_events(header, num_prompts_this_block);
-      prd::TimeBlock time_block;
+      petsird::TimeBlock time_block;
       time_block.id = t;
       time_block.prompt_events = prompts_this_block;
       writer.WriteTimeBlocks(time_block);

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: prd
+name: petsird
 channels:
   - conda-forge
   - defaults

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -1,5 +1,5 @@
 # Definition of the stream of data
-PrdExperiment: !protocol
+PETSIRD: !protocol
   sequence:
     header: Header
     timeBlocks: !stream

--- a/model/_package.yml
+++ b/model/_package.yml
@@ -1,4 +1,4 @@
-namespace: Prd
+namespace: PETSIRD
 
 cpp:
   sourcesOutputDir: ../cpp/generated

--- a/python/README.md
+++ b/python/README.md
@@ -6,10 +6,10 @@ The Python code shows piping the compact binary format to standard out and
 reading it from standard in. This can be used as follows:
 
 1. From the repo root `cd python`
-1. `python prd_generator.py | python prd_analysis.py`
+1. `python petsird_generator.py | python petsird_analysis.py`
 
 There is also a very basic utility to plot the scanner geometry. For instance
 ```
-python prd_generator.py > test.bin
-python prd_plot_scanner.py < test.bin`
+python petsird_generator.py > test.bin
+python petsird_plot_scanner.py < test.bin`
 

--- a/python/petsird_analysis.py
+++ b/python/petsird_analysis.py
@@ -5,11 +5,11 @@
 
 import sys
 import numpy
-import prd
+import petsird
 
 
 if __name__ == "__main__":
-    with prd.BinaryPrdExperimentReader(sys.stdin.buffer) as reader:
+    with petsird.BinaryPETSIRDReader(sys.stdin.buffer) as reader:
         header = reader.read_header()
         print(f"Subject ID: {header.exam.subject.id}")
         print(f"Scanner name: { header.scanner.model_name}")

--- a/python/petsird_generator.py
+++ b/python/petsird_generator.py
@@ -9,7 +9,7 @@ import random
 import numpy
 import numpy.typing as npt
 from collections.abc import Iterator
-import prd
+import petsird
 
 # these are constants for now
 NUMBER_OF_ENERGY_BINS = 3
@@ -24,13 +24,13 @@ NUMBER_OF_EVENTS = 1000
 COUNT_RATE = 500
 
 
-def make_coordinate(v: tuple) -> prd.Coordinate:
-    return prd.Coordinate(c=numpy.array(v, dtype=numpy.float32))
+def make_coordinate(v: tuple) -> petsird.Coordinate:
+    return petsird.Coordinate(c=numpy.array(v, dtype=numpy.float32))
 
 
-def get_crystal() -> prd.SolidVolume:
+def get_crystal() -> petsird.SolidVolume:
     """return a cuboid volume"""
-    crystal_shape = prd.BoxShape(
+    crystal_shape = petsird.BoxShape(
         corners=[
             make_coordinate((0, 0, 0)),
             make_coordinate((0, 0, CRYSTAL_LENGTH[2])),
@@ -42,20 +42,20 @@ def get_crystal() -> prd.SolidVolume:
             make_coordinate((CRYSTAL_LENGTH[0], CRYSTAL_LENGTH[1], 0)),
         ]
     )
-    return prd.BoxSolidVolume(shape=crystal_shape, material_id=1)
+    return petsird.BoxSolidVolume(shape=crystal_shape, material_id=1)
 
 
-def get_detector_module() -> prd.DetectorModule:
+def get_detector_module() -> petsird.DetectorModule:
     """return a module of NUM_CRYSTALS_PER_MODULE cuboids"""
     crystal = get_crystal()
-    rep_volume = prd.ReplicatedBoxSolidVolume(object=crystal)
+    rep_volume = petsird.ReplicatedBoxSolidVolume(object=crystal)
     N0 = NUM_CRYSTALS_PER_MODULE[0]
     N1 = NUM_CRYSTALS_PER_MODULE[1]
     N2 = NUM_CRYSTALS_PER_MODULE[2]
     for rep0 in range(N0):
         for rep1 in range(N1):
             for rep2 in range(N2):
-                transform = prd.RigidTransformation(
+                transform = petsird.RigidTransformation(
                     matrix=numpy.array(
                         (
                             (1.0, 0.0, 0.0, RADIUS + rep0 * CRYSTAL_LENGTH[0]),
@@ -68,21 +68,21 @@ def get_detector_module() -> prd.DetectorModule:
                 rep_volume.transforms.append(transform)
                 rep_volume.ids.append(rep0 + N0 * (rep1 + N1 * rep2))
 
-    return prd.DetectorModule(
+    return petsird.DetectorModule(
         detecting_elements=[rep_volume], detecting_element_ids=[0]
     )
 
 
-def get_scanner_geometry() -> prd.ScannerGeometry:
+def get_scanner_geometry() -> petsird.ScannerGeometry:
     """return a scanner build by rotating a module around the (0,0,1) axis"""
     detector_module = get_detector_module()
     radius = RADIUS
     angles = [2 * math.pi * i / NUM_MODULES for i in range(NUM_MODULES)]
 
-    rep_module = prd.ReplicatedDetectorModule(object=detector_module)
+    rep_module = petsird.ReplicatedDetectorModule(object=detector_module)
     module_id = 0
     for angle in angles:
-        transform = prd.RigidTransformation(
+        transform = petsird.RigidTransformation(
             matrix=numpy.array(
                 (
                     (math.cos(angle), math.sin(angle), 0.0, 0.0),
@@ -96,10 +96,10 @@ def get_scanner_geometry() -> prd.ScannerGeometry:
         module_id += 1
         rep_module.transforms.append(transform)
 
-    return prd.ScannerGeometry(replicated_modules=[rep_module], ids=[0])
+    return petsird.ScannerGeometry(replicated_modules=[rep_module], ids=[0])
 
 
-def get_scanner_info() -> prd.ScannerInformation:
+def get_scanner_info() -> petsird.ScannerInformation:
 
     scanner_geometry = get_scanner_geometry()
 
@@ -112,7 +112,7 @@ def get_scanner_info() -> prd.ScannerInformation:
     energyBinEdges = numpy.linspace(
         430, 650, NUMBER_OF_ENERGY_BINS + 1, dtype="float32"
     )
-    return prd.ScannerInformation(
+    return petsird.ScannerInformation(
         model_name="PETSIRD_TEST",
         scanner_geometry=scanner_geometry,
         tof_bin_edges=tofBinEdges,
@@ -123,22 +123,24 @@ def get_scanner_info() -> prd.ScannerInformation:
     )
 
 
-def get_header() -> prd.Header:
-    subject = prd.Subject(id="123456")
-    institution = prd.Institution(
+def get_header() -> petsird.Header:
+    subject = petsird.Subject(id="123456")
+    institution = petsird.Institution(
         name="Diamond Light Source",
         address="Harwell Science and Innovation Campus, Didcot, Oxfordshire, OX11 0DE, UK",
     )
-    return prd.Header(
-        exam=prd.ExamInformation(subject=subject, institution=institution),
+    return petsird.Header(
+        exam=petsird.ExamInformation(subject=subject, institution=institution),
         scanner=get_scanner_info(),
     )
 
 
-def get_events(header: prd.Header, num_events: int) -> Iterator[prd.CoincidenceEvent]:
+def get_events(
+    header: petsird.Header, num_events: int
+) -> Iterator[petsird.CoincidenceEvent]:
     detector_count = 5  # TODO header.scanner.number_of_detectors()
     for _ in range(num_events):
-        yield prd.CoincidenceEvent(
+        yield petsird.CoincidenceEvent(
             detector_ids=[
                 random.randrange(0, detector_count),
                 random.randrange(0, detector_count),
@@ -155,8 +157,8 @@ if __name__ == "__main__":
     # numpy random number generator
     rng = numpy.random.default_rng()
 
-    with prd.BinaryPrdExperimentWriter(sys.stdout.buffer) as writer:
-        # with prd.NDJsonPrdExperimentWriter(sys.stdout) as writer:
+    with petsird.BinaryPETSIRDWriter(sys.stdout.buffer) as writer:
+        # with petsird.NDJsonPETSIRDWriter(sys.stdout) as writer:
         header = get_header()
         writer.write_header(header)
         for t in range(NUMBER_OF_TIME_BLOCKS):
@@ -164,5 +166,5 @@ if __name__ == "__main__":
             prompts_this_block = list(get_events(header, num_prompts_this_block))
             # Normally we'd write multiple blocks, but here we have just one, so let's write a tuple with just one element
             writer.write_time_blocks(
-                (prd.TimeBlock(id=t, prompt_events=prompts_this_block),)
+                (petsird.TimeBlock(id=t, prompt_events=prompts_this_block),)
             )

--- a/python/petsird_plot_scanner.py
+++ b/python/petsird_plot_scanner.py
@@ -8,7 +8,7 @@
 import sys
 import numpy
 import numpy.typing as npt
-import prd
+import petsird
 
 import matplotlib.pyplot as plt
 
@@ -17,26 +17,28 @@ import matplotlib.pyplot as plt
 
 
 def transform_to_mat44(
-    transform: prd.RigidTransformation,
+    transform: petsird.RigidTransformation,
 ) -> npt.NDArray[numpy.float32]:
     return numpy.vstack([transform.matrix, [0, 0, 0, 1]])
 
 
-def mat44_to_transform(mat: npt.NDArray[numpy.float32]) -> prd.RigidTransformation:
-    return prd.RigidTransformation(matrix=mat[0:3, :])
+def mat44_to_transform(mat: npt.NDArray[numpy.float32]) -> petsird.RigidTransformation:
+    return petsird.RigidTransformation(matrix=mat[0:3, :])
 
 
-def coordinate_to_homogeneous(coord: prd.Coordinate) -> npt.NDArray[numpy.float32]:
+def coordinate_to_homogeneous(coord: petsird.Coordinate) -> npt.NDArray[numpy.float32]:
     return numpy.hstack([coord.c, 1])
 
 
-def homogeneous_to_coordinate(hom_coord: npt.NDArray[numpy.float32]) -> prd.Coordinate:
-    return prd.Coordinate(c=hom_coord[0:3])
+def homogeneous_to_coordinate(
+    hom_coord: npt.NDArray[numpy.float32],
+) -> petsird.Coordinate:
+    return petsird.Coordinate(c=hom_coord[0:3])
 
 
 def mult_transforms(
-    transforms: list[prd.RigidTransformation],
-) -> prd.RigidTransformation:
+    transforms: list[petsird.RigidTransformation],
+) -> petsird.RigidTransformation:
     """multiply rigid transformations"""
     mat = numpy.array(
         ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)),
@@ -49,8 +51,8 @@ def mult_transforms(
 
 
 def mult_transforms_coord(
-    transforms: list[prd.RigidTransformation], coord: prd.Coordinate
-) -> prd.Coordinate:
+    transforms: list[petsird.RigidTransformation], coord: petsird.Coordinate
+) -> petsird.Coordinate:
     """apply list of transformations to coordinate"""
     # TODO better to multiply with coordinates in sequence, as first multiplying the matrices
     hom = numpy.matmul(
@@ -61,21 +63,21 @@ def mult_transforms_coord(
 
 
 def transform_BoxShape(
-    transform: prd.RigidTransformation, box_shape: prd.BoxShape
-) -> prd.BoxShape:
-    return prd.BoxShape(
+    transform: petsird.RigidTransformation, box_shape: petsird.BoxShape
+) -> petsird.BoxShape:
+    return petsird.BoxShape(
         corners=[mult_transforms_coord([transform], c) for c in box_shape.corners]
     )
 
 
-def draw_BoxShape(ax, box: prd.BoxShape) -> None:
+def draw_BoxShape(ax, box: petsird.BoxShape) -> None:
     coords = numpy.array([c.c for c in box.corners])
     # mpl_toolkits.mplot3d.art3d.Line3D(coords[:, 0], coords[:, 1], coords[:, 2])
     ax.plot3D(coords[:, 0], coords[:, 1], coords[:, 2])
 
 
 if __name__ == "__main__":
-    with prd.BinaryPrdExperimentReader(sys.stdin.buffer) as reader:
+    with petsird.BinaryPETSIRDReader(sys.stdin.buffer) as reader:
         header = reader.read_header()
         # TODO somehow say we won't read the time blocks to avoid a ProtocolError
 


### PR DESCRIPTION
Rename the preliminary "prd" to "petsird".

I had to make some choices for how to write things. PETSIRD is really an acronym, so should be in caps. However, it is customary to make Python modules without caps. In fact, this is currently enforced by yardl, also in C++.

So, we have in C++
```c++
using petsird::hdf5::PETSIRDWriter;
```
and in Python
```python
    with petsird.BinaryPETSIRDWriter(sys.stdout.buffer) as writer:
```

I think that's still preferable over having "petsird" everywhere.

Fixes #27 